### PR TITLE
Setup Systemd service states and Template

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
   code_quality:
 
     name: SonarCloud Code Quality Check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
 
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ containerd_bin_path: /usr/local/bin
 containerd_files_mode: '0755'
 containerd_files_owner: root
 containerd_files_group: root
+containerd_systemd_service_setup: true
 containerd_systemd_template_in_file: containerd.service.j2
 containerd_systemd_template_out_dir: /etc/systemd/system
 containerd_systemd_template_out_file: containerd.service
@@ -34,7 +35,7 @@ containerd_systemd_service_state: started
 ### Variables table:
 
 Variable                                | Description
---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------
+--------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------
 containerd_app                          | Defines the app to install i.e. **containerd**
 containerd_version                      | Defined to dynamically fetch the desired version to install. Defaults to: **1.5.7**
 containerd_os                           | Defines OS type. Defaults to: **linux**
@@ -44,6 +45,7 @@ containerd_bin_path                     | Defined to dynamically set the appropr
 containerd_files_mode                   | Mode for the binaries file of containerd.
 containerd_files_owner                  | Owner for the binaries file of containerd.
 containerd_files_group                  | Group for the binaries file of containerd.
+containerd_systemd_service_setup        | Boolean for whether systemd service setup (systemd service generation, systemd boot start and state change) for containerd needs to be performed.
 containerd_systemd_template_in_file     | Template (Jinja) file to use as source for containerd's systemd service.
 containerd_systemd_template_out_dir     | Destination directory to store the generated Jinja template for containerd's systemd service.
 containerd_systemd_template_out_file    | Destination filename for containerd's systemd service.

--- a/README.md
+++ b/README.md
@@ -24,21 +24,31 @@ containerd_bin_path: /usr/local/bin
 containerd_files_mode: '0755'
 containerd_files_owner: root
 containerd_files_group: root
+containerd_systemd_template_in_file: containerd.service.j2
+containerd_systemd_template_out_dir: /etc/systemd/system
+containerd_systemd_template_out_file: containerd.service
+containerd_systemd_service_enable_state: yes
+containerd_systemd_service_state: started
 ```
 
 ### Variables table:
 
-Variable               | Description
----------------------- | --------------------------------------------------------------------------------------------------------------------------------
-containerd_app         | Defines the app to install i.e. **containerd**
-containerd_version     | Defined to dynamically fetch the desired version to install. Defaults to: **1.5.7**
-containerd_os          | Defines OS type. Defaults to: **linux**
-containerd_arch        | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **amd64**
-containerd_dl_url      | Defines URL to download the containerd binaries archive from.
-containerd_bin_path    | Defined to dynamically set the appropriate path to store containerd binaries into.
-containerd_files_mode  | Mode for the binaries file of containerd.
-containerd_files_owner | Owner for the binaries file of containerd.
-containerd_files_group | Group for the binaries file of containerd.
+Variable                                | Description
+--------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------
+containerd_app                          | Defines the app to install i.e. **containerd**
+containerd_version                      | Defined to dynamically fetch the desired version to install. Defaults to: **1.5.7**
+containerd_os                           | Defines OS type. Defaults to: **linux**
+containerd_arch                         | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **amd64**
+containerd_dl_url                       | Defines URL to download the containerd binaries archive from.
+containerd_bin_path                     | Defined to dynamically set the appropriate path to store containerd binaries into.
+containerd_files_mode                   | Mode for the binaries file of containerd.
+containerd_files_owner                  | Owner for the binaries file of containerd.
+containerd_files_group                  | Group for the binaries file of containerd.
+containerd_systemd_template_in_file     | Template (Jinja) file to use as source for containerd's systemd service.
+containerd_systemd_template_out_dir     | Destination directory to store the generated Jinja template for containerd's systemd service.
+containerd_systemd_template_out_file    | Destination filename for containerd's systemd service.
+containerd_systemd_service_enable_state | Defined to enable containerd systemd service at boot.
+containerd_systemd_service_state        | Defined to set the state of the containerd systemd service
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,8 @@ containerd_bin_path: /usr/local/bin
 containerd_files_mode: '0755'
 containerd_files_owner: root
 containerd_files_group: root
+containerd_systemd_template_in_file: containerd.service.j2
+containerd_systemd_template_out_dir: /etc/systemd/system
+containerd_systemd_template_out_file: containerd.service
+containerd_systemd_service_enable_state: yes
+containerd_systemd_service_state: started

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ containerd_bin_path: /usr/local/bin
 containerd_files_mode: '0755'
 containerd_files_owner: root
 containerd_files_group: root
+containerd_systemd_service_setup: true
 containerd_systemd_template_in_file: containerd.service.j2
 containerd_systemd_template_out_dir: /etc/systemd/system
 containerd_systemd_template_out_file: containerd.service

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,10 +6,12 @@
   service:
     name: "{{ containerd_app }}"
     enabled: "{{ containerd_systemd_service_enable_state }}"
-  when: ansible_virtualization_type != "docker"
+  when: containerd_systemd_service_setup
+  # when: ansible_virtualization_type != "docker"
 
 - name: "Set {{ containerd_app }} systemd service state"
   service:
     name: "{{ containerd_app }}"
     state: "{{ containerd_systemd_service_state }}"
-  when: ansible_virtualization_type != "docker"
+  when: containerd_systemd_service_setup
+  # when: ansible_virtualization_type != "docker"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+# handlers file for containerd
+# These handlers will only run when the virtualization type is NOT docker itself as docker doesn't support/handle systemd very well!
+
+- name: "Enable {{ containerd_app }} systemd service"
+  service:
+    name: "{{ containerd_app }}"
+    enabled: "{{ containerd_systemd_service_enable_state }}"
+  when: ansible_virtualization_type != "docker"
+
+- name: "Set {{ containerd_app }} systemd service state"
+  service:
+    name: "{{ containerd_app }}"
+    state: "{{ containerd_systemd_service_state }}"
+  when: ansible_virtualization_type != "docker"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,6 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  gather_facts: yes
   roles:
     - role: darkwizard242.containerd
+  vars:
+    containerd_systemd_service_setup: false

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,5 +1,6 @@
 ---
 - name: Converge
   hosts: all
+  gather_facts: yes
   roles:
     - role: darkwizard242.containerd

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ lint: |
     ansible-lint
     flake8
 platforms:
-  - name: ${DISTRO:-ubuntu-18.04}
+  - name: ${DISTRO:-ubuntu-20.04}
     image: "darkwizard242/ansible:${DISTRO:-ubuntu-18.04}"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -9,6 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 BINARIES_DIR = '/usr/local/bin/'
 BINARIES = ['containerd', 'containerd-shim', 'containerd-shim-runc-v1',
             'containerd-shim-runc-v2', 'ctr']
+SYSTEMD_FILE = '/etc/systemd/system/containerd.service'
 
 
 def test_containerd_binaries_exists(host):
@@ -25,3 +26,17 @@ def test_containerd_binaries_file(host):
         Tests if containerd binaries are a file type.
         """
         assert host.file(BINARIES_DIR + BINARY).is_file
+
+
+def test_containerd_systemd_exists(host):
+    """
+    Tests if containerd systemd file exists.
+    """
+    assert host.file(SYSTEMD_FILE).exists
+
+
+def test_containerd_systemd_file(host):
+    """
+    Tests if containerd systemd file is a file type.
+    """
+    assert host.file(SYSTEMD_FILE).is_file

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -11,3 +11,11 @@
     remote_src: yes
     extra_opts:
       - --strip-components=1
+
+- name: "Debian/Ubuntu Family | Provision systemd service for {{ containerd_app }} as {{ containerd_systemd_template_out_dir }}/{{ containerd_systemd_template_out_file }}"
+  template:
+    src: "{{ containerd_systemd_template_in_file }}"
+    dest: "{{ containerd_systemd_template_out_dir }}/{{ containerd_systemd_template_out_file }}"
+    mode: '0644'
+    owner: root
+    group: root

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -19,3 +19,6 @@
     mode: '0644'
     owner: root
     group: root
+  notify:
+    - "Enable {{ containerd_app }} systemd service"
+    - "Set {{ containerd_app }} systemd service state"

--- a/tasks/install_el.yml
+++ b/tasks/install_el.yml
@@ -11,3 +11,14 @@
     remote_src: yes
     extra_opts:
       - --strip-components=1
+
+- name: "EL Family | Provision systemd service for {{ containerd_app }} as {{ containerd_systemd_template_out_dir }}/{{ containerd_systemd_template_out_file }}"
+  template:
+    src: "{{ containerd_systemd_template_in_file }}"
+    dest: "{{ containerd_systemd_template_out_dir }}/{{ containerd_systemd_template_out_file }}"
+    mode: '0644'
+    owner: root
+    group: root
+  notify:
+    - "Enable {{ containerd_app }} systemd service"
+    - "Set {{ containerd_app }} systemd service state"

--- a/templates/containerd.service.j2
+++ b/templates/containerd.service.j2
@@ -15,13 +15,13 @@
 # limitations under the License.
 
 [Unit]
-Description=containerd container runtime
+Description={{ containerd_app }} container runtime
 Documentation=https://containerd.io
 After=network.target local-fs.target
 
 [Service]
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/containerd
+ExecStart={{ containerd_bin_path }}/{{ containerd_app }}
 
 Type=notify
 Delegate=yes

--- a/templates/containerd.service.j2
+++ b/templates/containerd.service.j2
@@ -1,0 +1,42 @@
+# {{ ansible_managed }}
+#
+# Copyright The containerd Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target local-fs.target
+
+[Service]
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/local/bin/containerd
+
+Type=notify
+Delegate=yes
+KillMode=process
+Restart=always
+RestartSec=5
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=infinity
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this version.
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Utilize a Jinja template for **containerd** to store as `systemd` service as `/etc/systemd/system/containerd.service`
- Add template tasks for the Jinja template
- Add notify to tasks for handlers that set **containerd's** systemd service and boot start.
- Set condition in handlers to only run when `containerd_systemd_service_setup` is set to true
- Update TestInfra suite to include functions that verify systemd service file's existence.